### PR TITLE
Update display range on options change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modui-calendar-pane",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "./src/moduiCalendarPane.js",
   "keywords": [

--- a/src/moduiCalendarPane.js
+++ b/src/moduiCalendarPane.js
@@ -92,6 +92,7 @@ module.exports = Super.extend( {
 		if( 'maxDate' in options ) {
 			this._setMaxDate( options.maxDate );
 		}
+		this._recalculateAndSetDisplayDateRange();
 	},
 
 	_setSelectedDate : function( date ) {

--- a/src/moduiCalendarPane.js
+++ b/src/moduiCalendarPane.js
@@ -92,7 +92,10 @@ module.exports = Super.extend( {
 		if( 'maxDate' in options ) {
 			this._setMaxDate( options.maxDate );
 		}
-		this._recalculateAndSetDisplayDateRange();
+
+		if( 'firstVisibleMonth' in options ) {
+			this._recalculateAndSetDisplayDateRange();
+		}
 	},
 
 	_setSelectedDate : function( date ) {


### PR DESCRIPTION
Hi @dgbeck. I'm asking for this change because `firstVisibleMonth` option may be changed, and when that happens, it's needed to update the display range.

This was found when fixing [Mobilized QA-292](https://github.com/rotundasoftware/mobilized-qa/issues/292).

Please merge if you agree with this change. Thanks!